### PR TITLE
Add options to httparty

### DIFF
--- a/lib/client.rb
+++ b/lib/client.rb
@@ -28,16 +28,16 @@ module TotalVoice
     #   - +Access-Token+ -> Access-Token TotalVoice
     #   - +host+ -> Base URL para API
     #
-    def initialize(access_token, host = nil)
+    def initialize(access_token, host = nil, options = {})
       @access_token     = access_token
       @host             = host ? host : ENDPOINT
       @options = {
         headers: {
-          "Access-Token" => @access_token,
-          "Content-Type" => "application/json",
-          "Accept" => "application/json"
+          'Access-Token' => @access_token,
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json'
         }
-      }
+      }.merge(options)
 
       @audio = nil
       @bina = nil


### PR DESCRIPTION
Não é possível passar nenhum argumento do httparty na requisição. Tenho casos onde um simples get na consulta de saldo chega levar 2 minutos e a conexão é interrompida. Gostaria de poder passar o timeout para não ficar esperando até que a api expire a conexão.

Minha sugestão é poder passar os argumentos do httparty no `initialize` da classe `httparty::API`

```ruby
def initialize(access_token, host = nil, options)
  ...
  @options = {
    headers: {
      "Access-Token" => @access_token,
      "Content-Type" => "application/json",
      "Accept" => "application/json"
    }
  }.merge!(options)
  ...
end
```

Assim poderíamos chamar a API da seguinte forma:

```ruby
TotalVoice::API.new(access_token, host, { timeout: 10 })
```